### PR TITLE
Issue #SB-9094 chore: Add dialcode metrics es indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ platform-ui/node_modules
 **/target
 .cache
 .idea
+.DS_Store
 derby.log
 platform-analytics/metastore_db
 dependency-reduced-pom.xml

--- a/platform-jobs/samza/composite-search-indexer/src/main/java/org/ekstep/jobs/samza/service/util/DialCodeMetricsIndexer.java
+++ b/platform-jobs/samza/composite-search-indexer/src/main/java/org/ekstep/jobs/samza/service/util/DialCodeMetricsIndexer.java
@@ -1,0 +1,101 @@
+package org.ekstep.jobs.samza.service.util;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.ekstep.common.Platform;
+import org.ekstep.jobs.samza.util.JobLogger;
+import org.ekstep.searchindex.elasticsearch.ElasticSearchUtil;
+import org.ekstep.searchindex.util.CompositeSearchConstants;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DialCodeMetricsIndexer extends AbstractESIndexer {
+
+    private JobLogger LOGGER = new JobLogger(DialCodeMetricsIndexer.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    protected void init() {
+        ElasticSearchUtil.initialiseESClient(CompositeSearchConstants.DIAL_CODE_METRICS_INDEX,
+                Platform.config.getString("search.es_conn_info"));
+    }
+
+    public void createDialCodeIndex() throws IOException {
+        String settings = "{\"number_of_shards\":5}";
+        String mappings = "{\"dcm\":{\"dynamic\":false,\"properties\":{\"dial_code\":{\"type\":\"keyword\"},\"total_dial_scans_local\":{\"type\":\"double\"},\"total_dial_scans_global\":{\"type\":\"double\"},\"average_scans_per_day\":{\"type\":\"double\"},\"last_scan\":{\"type\":\"date\",\"format\":\"strict_date_optional_time||epoch_millis\"},\"first_scan\":{\"type\":\"date\",\"format\":\"strict_date_optional_time||epoch_millis\"}}}}";
+        ElasticSearchUtil.addIndex(CompositeSearchConstants.DIAL_CODE_METRICS_INDEX,
+                CompositeSearchConstants.DIAL_CODE_METRICS_INDEX_TYPE, settings, mappings);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Map<String, Object> getIndexDocument(Map<String, Object> message, boolean updateRequest)
+            throws IOException {
+        Map<String, Object> indexDocument = new HashMap<>();
+        // The nodeUniqueId will be the dialcodeId to be inserted or updated
+        String uniqueId = (String) message.get("nodeUniqueId");
+        if (updateRequest) {
+            String documentJson = ElasticSearchUtil.getDocumentAsStringById(CompositeSearchConstants.DIAL_CODE_METRICS_INDEX,
+                    CompositeSearchConstants.DIAL_CODE_METRICS_INDEX_TYPE, uniqueId);
+            if (documentJson != null && !documentJson.isEmpty()) {
+                indexDocument = mapper.readValue(documentJson, new TypeReference<Map<String, Object>>() {
+                });
+            }
+        }
+        Map transactionData = (Map) message.get("transactionData");
+        if (transactionData != null) {
+            Map<String, Object> addedProperties = (Map<String, Object>) transactionData.get("properties");
+            if (addedProperties != null && !addedProperties.isEmpty()) {
+                for (Map.Entry<String, Object> propertyMap : addedProperties.entrySet()) {
+                    if (propertyMap != null && propertyMap.getKey() != null) {
+                        String propertyName = propertyMap.getKey();
+                        // new value of the property
+                        Object propertyNewValue = ((Map<String, Object>) propertyMap.getValue()).get("nv");
+                        // New value from transaction data is null, then remove
+                        // the property from document
+                        if (propertyNewValue == null)
+                            indexDocument.remove(propertyName);
+                        else {
+                            indexDocument.put(propertyName, propertyNewValue);
+                        }
+                    }
+                }
+            }
+        }
+        indexDocument.put("dial_code", message.get("nodeUniqueId"));
+        indexDocument.put("objectType", message.get("objectType"));
+        return indexDocument;
+    }
+
+    private void upsertDocument(String uniqueId, String jsonIndexDocument) throws Exception {
+        ElasticSearchUtil.addDocumentWithId(CompositeSearchConstants.DIAL_CODE_METRICS_INDEX,
+                CompositeSearchConstants.DIAL_CODE_METRICS_INDEX_TYPE, uniqueId, jsonIndexDocument);
+        LOGGER.info("Indexed dialcode metrics successfully for dialcode " + uniqueId);
+    }
+
+    public void upsertDocument(String uniqueId, Map<String, Object> message) throws Exception {
+        LOGGER.info(uniqueId + " is indexing into dialcodemetrics.");
+        String operationType = (String) message.get("operationType");
+        switch (operationType) {
+            case CompositeSearchConstants.OPERATION_CREATE: {
+                Map<String, Object> indexDocument = getIndexDocument(message, false);
+                String jsonIndexDocument = mapper.writeValueAsString(indexDocument);
+                upsertDocument(uniqueId, jsonIndexDocument);
+                break;
+            }
+            case CompositeSearchConstants.OPERATION_UPDATE: {
+                Map<String, Object> indexDocument = getIndexDocument(message, true);
+                String jsonIndexDocument = mapper.writeValueAsString(indexDocument);
+                upsertDocument(uniqueId, jsonIndexDocument);
+                break;
+            }
+            case CompositeSearchConstants.OPERATION_DELETE: {
+                ElasticSearchUtil.deleteDocument(CompositeSearchConstants.DIAL_CODE_INDEX,
+                        CompositeSearchConstants.DIAL_CODE_INDEX_TYPE, uniqueId);
+                break;
+            }
+        }
+    }
+
+}

--- a/platform-jobs/samza/composite-search-indexer/src/test/java/org/ekstep/jobs/samza/test/ESIndexerTest.java
+++ b/platform-jobs/samza/composite-search-indexer/src/test/java/org/ekstep/jobs/samza/test/ESIndexerTest.java
@@ -1,0 +1,94 @@
+package org.ekstep.jobs.samza.test;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.samza.config.Config;
+import org.apache.samza.metrics.Counter;
+import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.TaskContext;
+import org.apache.samza.task.TaskCoordinator;
+import org.ekstep.jobs.samza.service.CompositeSearchIndexerService;
+import org.ekstep.jobs.samza.service.util.CompositeSearchIndexer;
+import org.ekstep.jobs.samza.service.util.DialCodeIndexer;
+import org.ekstep.jobs.samza.service.util.DialCodeMetricsIndexer;
+import org.ekstep.jobs.samza.task.CompositeSearchIndexerTask;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class ESIndexerTest {
+
+    private MessageCollector collectorMock;
+    private TaskContext contextMock;
+    private MetricsRegistry metricsRegistry;
+    private Counter counter;
+    private TaskCoordinator coordinatorMock;
+    private IncomingMessageEnvelope envelopeMock;
+    private SystemStreamPartition streamMock;
+    private Config configMock;
+    private CompositeSearchIndexerTask compositeSearchIndexerTask;
+    private CompositeSearchIndexerService compositeSearchIndexerService;
+    private CompositeSearchIndexer csIndexerMock;
+    private DialCodeIndexer dcIndexerMock;
+    private DialCodeMetricsIndexer dialCodeMetricsIndexerMock;
+
+    private String dialcodeMetricsValidEvent = "{\"ets\":1543561000015,\"nodeUniqueId\":\"QR1234\",\"transactionData\":{\"properties\":{\"average_scans_per_day\":{\"nv\":2},\"last_scan\":{\"nv\":1541456052000},\"total_dial_scans_global\":{\"nv\":25},\"total_dial_scans_local\":{\"nv\":25},\"first_scan\":{\"nv\":1540469152000}}},\"objectType\":\"\",\"operationType\":\"UPDATE\",\"nodeType\":\"DIALCODE_METRICS\",\"graphId\":\"domain\",\"nodeGraphId\":0}";
+
+    @Before
+    public void setUp() throws Exception {
+
+        collectorMock = Mockito.mock(MessageCollector.class);
+        contextMock = Mockito.mock(TaskContext.class);
+        metricsRegistry = Mockito.mock(MetricsRegistry.class);
+        counter = Mockito.mock(Counter.class);
+        coordinatorMock = Mockito.mock(TaskCoordinator.class);
+        envelopeMock = mock(IncomingMessageEnvelope.class);
+        configMock = Mockito.mock(Config.class);
+
+        dialCodeMetricsIndexerMock = Mockito.mock(DialCodeMetricsIndexer.class);
+        streamMock = Mockito.mock(SystemStreamPartition.class);
+
+        stub(envelopeMock.getSystemStreamPartition()).toReturn(streamMock);
+        stub(metricsRegistry.newCounter(anyString(), anyString())).toReturn(counter);
+        stub(contextMock.getMetricsRegistry()).toReturn(metricsRegistry);
+        stub(streamMock.getStream()).toReturn("telemetry.with_location");
+        stub(configMock.get("task.window.ms")).toReturn("10");
+        stub(configMock.get("definitions.update.window.ms")).toReturn("20");
+
+        compositeSearchIndexerService = Mockito.spy(new CompositeSearchIndexerService(csIndexerMock, dcIndexerMock, dialCodeMetricsIndexerMock));
+        doNothing().when(compositeSearchIndexerService).initialize(configMock);
+        compositeSearchIndexerTask = new CompositeSearchIndexerTask(configMock, contextMock, compositeSearchIndexerService);
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDialcodeMetricsEventIndexer() throws Exception {
+        stub(envelopeMock.getMessage()).toReturn(getEvent(dialcodeMetricsValidEvent));
+        ArgumentCaptor<String> stringArgument = ArgumentCaptor.forClass(String.class);
+        Class<Map<String, Object>> mapClass = (Class<Map<String, Object>>)(Class) Map.class;
+        ArgumentCaptor<Map<String, Object>> mapArgument = ArgumentCaptor.forClass(mapClass);
+        compositeSearchIndexerTask.process(envelopeMock, collectorMock, coordinatorMock);
+        verify(dialCodeMetricsIndexerMock, times(1))
+                .upsertDocument(stringArgument.capture(), mapArgument.capture());
+        assertEquals("QR1234", stringArgument.getValue());
+        Map<String, Object> message = mapArgument.getValue();
+        assertEquals("UPDATE", message.get("operationType"));
+        assertEquals("DIALCODE_METRICS", message.get("nodeType"));
+    }
+
+    public static Map<String, Object> getEvent(String message) {
+        return new Gson().fromJson(message, new TypeToken<Map<String, Object>>() {}.getType());
+    }
+}

--- a/searchIndex-platform/module/searchindex-common/src/main/java/org/ekstep/searchindex/util/CompositeSearchConstants.java
+++ b/searchIndex-platform/module/searchindex-common/src/main/java/org/ekstep/searchindex/util/CompositeSearchConstants.java
@@ -56,8 +56,11 @@ public class CompositeSearchConstants {
 	public static final String CONDITION_SET_SHOULD = "should";
 	public static final String SEARCH_OPERATION_SOFT = "soft";
 	public static final String NODE_TYPE_EXTERNAL = "EXTERNAL";
+	public static final String NODE_TYPE_DIALCODE_METRICS = "DIALCODE_METRICS";
 	public static String DIAL_CODE_INDEX = "dialcode";
+	public static String DIAL_CODE_METRICS_INDEX = "dialcodemetrics";
 	public static final String DIAL_CODE_INDEX_TYPE = "dc";
+	public static final String DIAL_CODE_METRICS_INDEX_TYPE = "dcm";
 	public static final String SEARCH_OPERATION_NOT_IN_OPERATOR = "notIn";
 	public static final String SEARCH_OPERATION_NOT_IN = "NT_IN";
 	public static final String SEARCH_OPERATION_CONTAINS_OPERATOR = "contains";


### PR DESCRIPTION
@maheshkumargangula @PradyumnaNagendra @amitpriyadarshi 

1. DialcodeMetricsIndexer is used to use the CompositeSearch Indexer job to index dialcode metrics to the local dialcodemetrics index. The event will have the total cumulative dialcode scans for a give dialcode.
2. The code has been refactored a little bit so that the ES indexer job can be unit tested.