### PR TITLE
DIK-3249 - Certificate Trigger logic update

### DIFF
--- a/platform-jobs/samza/course-batch-updater/pom.xml
+++ b/platform-jobs/samza/course-batch-updater/pom.xml
@@ -17,7 +17,7 @@
             <scala.version>2.11</scala.version>
             <hadoop.version>2.6.2</hadoop.version>
         </properties>
-        <version>0.0.51</version>
+        <version>0.0.52</version>
     <dependencies>
         <dependency>
             <groupId>org.ekstep</groupId>

--- a/platform-jobs/samza/distribution/pom.xml
+++ b/platform-jobs/samza/distribution/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.ekstep</groupId>
 			<artifactId>course-batch-updater</artifactId>
-			<version>0.0.51</version>
+			<version>0.0.52</version>
 			<type>tar.gz</type>
 			<classifier>distribution</classifier>
 		</dependency>

--- a/platform-modules/manager/src/main/java/org/ekstep/taxonomy/controller/ContentV3Controller.java
+++ b/platform-modules/manager/src/main/java/org/ekstep/taxonomy/controller/ContentV3Controller.java
@@ -43,7 +43,7 @@ import java.util.Map;
  * @author Azhar
  */
 @Controller
-@RequestMapping("/content/v3") 
+@RequestMapping("/content/v3")
 public class ContentV3Controller extends BaseController {
 
 	@Autowired


### PR DESCRIPTION
Set `reIssue` to true only when there is change to the db vs local computed count.
Added `trigger: auto-issue` to identify the auto-issue events.