### PR TITLE
KP flink - config updates

### DIFF
--- a/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/flink-jobs-deploy/defaults/main.yml
@@ -40,6 +40,7 @@ restart_attempts: 3
 restart_delay: 30000 # in milli-seconds
 producer_max_request_size: 1572864
 dp_redis_host: "{{ groups['dp-redis'][0] }}"
+kp_redis_host: "{{ groups['redisall'][0] }}"
 
 ### Activity Aggregate job related vars
 activity_agg_consumer_parallelism: 1

--- a/kubernetes/helm_charts/datapipeline_jobs/values.j2
+++ b/kubernetes/helm_charts/datapipeline_jobs/values.j2
@@ -63,7 +63,7 @@ base_config: |
       restart-strategy.delay = {{ restart_delay }} # in milli-seconds
     }
     redis {
-      host = {{ dp_redis_host }}
+      host = {{ kp_redis_host }}
       port = 6379
     }
     lms-cassandra {
@@ -124,12 +124,14 @@ relation-cache-updater:
     lms-cassandra {
           keyspace = "{{ middleware_hierarchy_keyspace }}"
           table = "{{ middleware_content_hierarchy_table }}"
-      }
+    }
     redis {
-      database {
-        relationCache.id = 10
-        collectionCache.id = 5
-      }
+      database.index = 10
+    }
+    dp-redis {
+      host = {{ dp_redis_host }}
+      port = 6379
+      database.index = 5
     }
 
   flink-conf: |+

--- a/platform-modules/manager/src/main/java/org/ekstep/taxonomy/controller/ContentV3Controller.java
+++ b/platform-modules/manager/src/main/java/org/ekstep/taxonomy/controller/ContentV3Controller.java
@@ -44,7 +44,7 @@ import java.util.Map;
  */
 @Controller
 @RequestMapping("/content/v3") 
-public class ContentV3Controller extends BaseController  {
+public class ContentV3Controller extends BaseController {
 
 	@Autowired
 	private IContentManager contentManager;


### PR DESCRIPTION
1. kp_redis_host variable for flink deploy role.
- kp_redis - for relation cache and general kp jobs usage.
- dp_redis - for specific to dp data.