### PR TITLE
fix: do not run schema updates on all nodes

### DIFF
--- a/ansible/roles/cassandra-db-update/tasks/main.yml
+++ b/ansible/roles/cassandra-db-update/tasks/main.yml
@@ -13,6 +13,8 @@
   with_items:
     - "data.cql"
     - "dialcode.cql"
+  delegate_to: "{{ groups['cassandra'][0] }}"
+  run_once: true
 
   
 - name: run cql 
@@ -21,3 +23,5 @@
   with_items:
     - "data.cql"
     - "dialcode.cql"
+  delegate_to: "{{ groups['cassandra'][0] }}"
+  run_once: true

--- a/ansible/roles/cassandra-db-update/tasks/main.yml
+++ b/ansible/roles/cassandra-db-update/tasks/main.yml
@@ -13,7 +13,6 @@
   with_items:
     - "data.cql"
     - "dialcode.cql"
-  delegate_to: "{{ groups['cassandra'][0] }}"
   run_once: true
 
   
@@ -23,5 +22,4 @@
   with_items:
     - "data.cql"
     - "dialcode.cql"
-  delegate_to: "{{ groups['cassandra'][0] }}"
   run_once: true


### PR DESCRIPTION
- Cassandra sends the schema updates to other nodes so its not required to run on all nodes
- Sometimes running on all nodes causes instability if schema update is not propogated and another node concurrently tries to update the schema
- Solves issues such as `org.apache.cassandra.exceptions.ConfigurationException: Column family ID mismatch (found e5e541e0-710e-11eb-bca4-c3f6e93f4591; expected e5d42ae0-710e-11eb-9674-2df22627c7a5)`