### PR TITLE
fix: use the username defined in inventory hosts file

### DIFF
--- a/ansible/roles/cassandra-restore/defaults/main.yml
+++ b/ansible/roles/cassandra-restore/defaults/main.yml
@@ -1,6 +1,6 @@
 cassandra_backup_azure_container_name: lp-cassandra-backup
 
-user: deployer
+user: "{{ ansible_ssh_user }}"
 restore_path: /home/{{user}}
 backup_folder_name: cassandra_backup
 backup_dir: "{{restore_path}}/cassandra_backup"

--- a/ansible/roles/dialcode_insert/defaults/main.yml
+++ b/ansible/roles/dialcode_insert/defaults/main.yml
@@ -1,1 +1,1 @@
-home_dir: /home/deployer
+home_dir: "/home/{{ ansible_ssh_user }}/"


### PR DESCRIPTION
- Use the inventory username instead of hardcoding as `deployer`
- Fixes https://github.com/project-sunbird/sunbird-community/discussions/352#discussion-3386485