### PR TITLE
owner and group set to hduser and hadoop for yarn provisioning scala copy task

### DIFF
--- a/ansible/roles/yarn/tasks/common.yml
+++ b/ansible/roles/yarn/tasks/common.yml
@@ -69,6 +69,8 @@
     copy:
       src: "/usr/local/scala-{{scala_version}}/lib/{{item}}"
       dest: "{{hadoop_yarn_home}}/share/hadoop/hdfs/lib/"
+      owner: hduser
+      group: hadoop
       remote_src: true
     with_items:
       - scala-compiler.jar


### PR DESCRIPTION
Scala libraries scala-compiler.jar and scala-library.jar were being copied over as root, which resulted in hduser not being able to access them on the VMs where hduser is not permitted to read files owned by root. This issue is also present in sunbird-data-pipeline repo as the same script is present there as well.