### PR TITLE
ED-2080: update zookeeper hostname in Deploy/KnowledgePlatform/KafkaSetup

### DIFF
--- a/ansible/roles/setup-kafka/defaults/main.yml
+++ b/ansible/roles/setup-kafka/defaults/main.yml
@@ -2,6 +2,9 @@ env: dev
 ingestion_kafka_topics: ""
 ingestion_kafka_overriden_topics: ""
 
+ingestion_zookeeper_ip: "{{ groups['ingestion-cluster-zookeeper'][0] }}"
+processing_zookeeper_ip: "{{ groups['processing-cluster-zookeepers'][0] }}"
+
 processing_kafka_topics:
   - name: telemetry.raw
     num_of_partitions: 4

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -13,12 +13,6 @@
   tags:
     - ingestion-kafka
 
-- name: override replication count
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --replication-factor {{ item.replication_factor }}
-  with_items: "{{ingestion_kafka_overriden_topics}}"
-  when: kafka_id=="1" and item.replication_factor is defined
-  tags:
-    - ingestion-kafka
 
 - name: override partition count
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }}
@@ -42,13 +36,6 @@
   tags:
     - processing-kafka
 
-
-- name: override replication count
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --replication-factor {{ item.replication_factor }}
-  with_items: "{{processing_kafka_overriden_topics}}"
-  when: kafka_id=="1" and item.replication_factor is defined
-  tags:
-    - processing-kafka
 
 - name: override partition count
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }}

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{ingestion_kafka_topics}}"
   ignore_errors: true
   when: kafka_id=="1"
@@ -7,14 +7,14 @@
     - ingestion-kafka
 
 - name: override retention time
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --alter --topic {{env}}.{{item.name}} --config retention.ms={{ item.retention_time }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --config retention.ms={{ item.retention_time }}
   with_items: "{{ingestion_kafka_overriden_topics}}"
   when: kafka_id=="1" and item.retention_time is defined
   tags:
     - ingestion-kafka
 
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{processing_kafka_topics}}"
   ignore_errors: true
   when: kafka_id=="1"
@@ -22,7 +22,7 @@
     - processing-kafka
 
 - name: override retention time
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --alter --topic {{env}}.{{item.name}} --config retention.ms={{ item.retention_time }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --config retention.ms={{ item.retention_time }}
   with_items: "{{processing_kafka_overriden_topics}}"
   when: kafka_id=="1" and item.retention_time is defined  
   tags:

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -13,6 +13,20 @@
   tags:
     - ingestion-kafka
 
+- name: override replication count
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --replication-factor {{ item.replication_factor }}
+  with_items: "{{ingestion_kafka_overriden_topics}}"
+  when: kafka_id=="1" and item.replication_factor is defined
+  tags:
+    - ingestion-kafka
+
+- name: override partition count
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }}
+  with_items: "{{ingestion_kafka_overriden_topics}}"
+  when: kafka_id=="1" and item.num_of_partitions is defined
+  tags:
+    - ingestion-kafka
+
 - name: create topics
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{processing_kafka_topics}}"
@@ -25,5 +39,20 @@
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --config retention.ms={{ item.retention_time }}
   with_items: "{{processing_kafka_overriden_topics}}"
   when: kafka_id=="1" and item.retention_time is defined  
+  tags:
+    - processing-kafka
+
+
+- name: override replication count
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --replication-factor {{ item.replication_factor }}
+  with_items: "{{processing_kafka_overriden_topics}}"
+  when: kafka_id=="1" and item.replication_factor is defined
+  tags:
+    - processing-kafka
+
+- name: override partition count
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --alter --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }}
+  with_items: "{{processing_kafka_overriden_topics}}"
+  when: kafka_id=="1" and item.num_of_partitions is defined
   tags:
     - processing-kafka

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -2,7 +2,7 @@
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{ingestion_zookeeper_ip}}:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{ingestion_kafka_topics}}"
   ignore_errors: true
-  when: kafka_id=="1"
+  when: kafka_id=="1" and ingestion_kafka_topics | length > 0
   tags:
     - ingestion-kafka
 

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -31,7 +31,7 @@
   command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{processing_zookeeper_ip}}:2181 --create --topic {{env}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{processing_kafka_topics}}"
   ignore_errors: true
-  when: kafka_id=="1"
+  when: kafka_id=="1" and processing_kafka_topics | length > 0
   tags:
     - processing-kafka
 


### PR DESCRIPTION
changed the zookeepr details from localhost to zookeeper host

This is because in base implementation where kafka and zookeeper are on the same vm, then the existing setup works
But in case if we have dedicated kafka cluster and a zookeeper cluster, the kafka topic creation fails